### PR TITLE
float price work with , or . and cant be text

### DIFF
--- a/app/templates/products/form.html
+++ b/app/templates/products/form.html
@@ -52,11 +52,12 @@
                 </div>
                 <div>
                     <label for="price" class="form-label">Precio</label>
-                    <input type="float"
+                    <input type="number"
                         id="price"
                         name="price"
                         class="form-control {% if errors.price %}is-invalid{% endif %}"
                         value="{{ product.price }}"
+                        min="0.01"
                         required/>
 
                     {% if errors.price %}


### PR DESCRIPTION
## Description of Change

> Fix an error that occurs when you put "," float or a text in the price value

## Type of Change

- [x] Bug fix (a fix to an existing functionality)
- [ ] New feature (new functionality that does not break existing features)
- [ ] Breaking change (a change that may introduce issues or requires caution. Include instructions if this is marked)

## Related Issue

> 

## Checklists

- [ ] No linting errors
- [ ] Relevant tests are created and run correctly
