### PR TITLE
add tests for client phone

### DIFF
--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -91,6 +91,19 @@ class ClientsTest(TestCase):
         )
 
         self.assertContains(response, "El nombre solo puede contener letras y espacios")
+
+    def test_validation_invalid_phone(self):
+        response = self.client.post(
+            reverse("clients_form"),
+            data={
+                "name": "Juan Sebastian Veron",
+                "phone": "221555232",
+                "address": "13 y 44",
+                "email": "brujita75@vetsoft.com"
+            },
+        )
+        self.assertEqual(response.status_code, 200) # not redirected
+        self.assertContains(response, "El teléfono debe comenzar con 54")
         
     def test_edit_user_with_valid_data(self):
         client = Client.objects.create(

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -200,7 +200,6 @@ class PetModelTest(TestCase):
                 "client": 1,
             },
         )
-        print(errors)
         self.assertTrue(is_success)
 
 

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -190,6 +190,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         self.page.get_by_role("link", name="Editar").click()
         self.page.get_by_label("Teléfono").fill("435345354")
         self.page.get_by_role("button", name="Guardar").click()
+        expect(self.page.get_by_label("form")).to_contain_text("El teléfono debe comenzar con 54")
 
 
     def test_should_be_able_to_create_a_new_client(self):


### PR DESCRIPTION
## Description of Change

Add integration and e2e tests to validate that phone numbers must start with 54

## Type of Change

- [ ] Bug fix (a fix to an existing functionality)
- [ ] New feature (new functionality that does not break existing features)
- [ ] Breaking change (a change that may introduce issues or requires caution. Include instructions if this is marked)


## Checklists

- [x] No linting errors
- [x] Relevant tests are created and run correctly
